### PR TITLE
fixed utils.urlPatternToRegex

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -21,9 +21,7 @@ utils.splitName = function(name) {
  * will have a . prepended to it.
  */
 utils.urlPatternToRegex = function(pattern){
-  pattern = pattern.replace(/\//g, '\/');
-  pattern = pattern.replace(/\./g, '\.');
-  pattern = pattern.replace(/\-/g, '\-');
+  pattern = pattern.replace(/\./g, '\\.');
   pattern = pattern.replace(/\*/g, '.*');
   return new RegExp(pattern);
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,7 +22,7 @@ describe('utils', function(){
   
   it('urlPatternToRegex', function(){
     var regex = utils.urlPatternToRegex('https://familysearch.org/pal:/MM9.1.1/*');
-    expect(regex.source).to.equal('https:\/\/familysearch\.org\/pal:\/MM9\.1\.1\/.*');
+    expect(regex.source).to.equal('https:\\/\\/familysearch\\.org\\/pal:\\/MM9\\.1\\.1\\/.*');
     expect(regex.test('https://familysearch.org/pal:/MM9.1.1/MZ87-RG9')).to.be.true;
     expect(regex.test('https://familysearch.org/pal:/MM9.1.1/M47-RG9')).to.be.true;
     expect(regex.test('https://familysearch.org/pal/MM9.1.1/M47-RG9')).to.not.be.true;


### PR DESCRIPTION
utils test was failing at line 25. 
* Changed expected result by changing
all ‘\’ to ‘\\’. 
* Changed utils.urlPatternToRegex removed all but two
changes to pattern. and updated ‘\.’ to ‘\\.' . 

All tests are now passing. 

Might want to look into handling of reggex