### PR TITLE
Adding ancestrylibrary(.ca|.com|.com.au) support

### DIFF
--- a/src/scrapers/ancestry-person.js
+++ b/src/scrapers/ancestry-person.js
@@ -4,7 +4,8 @@ var debug = require('debug')('genscrape:scrapers:ancestry-person'),
 
 var urls = [
   utils.urlPatternToRegex('https://www.ancestry.(ca|co.uk|com|com.au)/family-tree/person/tree/*/person/*'),
-  utils.urlPatternToRegex('https://www.ancestryinstitution.(ca|co.uk|com|com.au)/family-tree/person/tree/*/person/*')
+  utils.urlPatternToRegex('https://www.ancestryinstitution.(ca|co.uk|com|com.au)/family-tree/person/tree/*/person/*'),
+  utils.urlPatternToRegex('https://www.ancestrylibrary.(ca|com|com.au)/family-tree/person/tree/*/person/*')
 ];
 
 var eventConfig = [

--- a/src/scrapers/ancestry-record.js
+++ b/src/scrapers/ancestry-record.js
@@ -6,7 +6,8 @@ var debug = require('debug')('genscrape:scrapers:ancestry-record'),
 
 var urls = [
   utils.urlPatternToRegex('https://search.ancestry.(ca|co.uk|com|com.au)/cgi-bin/sse.dll*'),
-  utils.urlPatternToRegex('https://search.ancestryinstitution.(ca|co.uk|com|com.au)/cgi-bin/sse.dll*')
+  utils.urlPatternToRegex('https://search.ancestryinstitution.(ca|co.uk|com|com.au)/cgi-bin/sse.dll*'),
+  utils.urlPatternToRegex('https://search.ancestrylibrary.(ca|com|com.au)/cgi-bin/sse.dll*')
 ];
 
 var eventsConfig = [


### PR DESCRIPTION
In addition to institutional access to Ancestry being through _ancestryinstitution.(ca|co.uk|com|com.au)_, libraries provide access to Ancestry through _ancestrylibrary.(ca|com|com.au)_.  

After some quick research, it appears _ancestrylibrary.co.uk_ specifically is not in use, so it has been omitted.

Some additional info on AncestryLibrary can be found [here](https://www.ancestrylibrary.com/LearningCenter), [here](https://proquest.libguides.com/ancestrylibraryedition) and [here](https://calgarylibrary.ca/read-learn-and-explore/digital-library/ancestry-library-edition/).

(Apologies if I'm going about submitting a pull request the wrong way -- this is literally my first day on GitHub.)